### PR TITLE
Move syntax toggling logic to individual tool classes

### DIFF
--- a/src/plugins/markdown/Toolbar/MakeTool.js
+++ b/src/plugins/markdown/Toolbar/MakeTool.js
@@ -1,7 +1,6 @@
 class MakeTool {
-    constructor(editor, syntax, title) {
+    constructor(editor, title) {
         this.editor = editor;
-        this.syntax = syntax; // Markdown syntax (e.g., ** for bold, * for italic)
         this.defaultText = `${title} text`; // Default text if nothing is selected
         this.button = this.createButton();
         this.title = title
@@ -15,51 +14,8 @@ class MakeTool {
         button.type = 'button';
         button.title = this.title;
         button.className = `markdown-btn ${buttonClass}${buttonClass == 'preview-btn' ? ' sticky right-0 bg-stone-100 dark:bg-stone-900 ' : ' ' }p-2 hover:bg-stone-200 dark:hover:bg-stone-600 rounded duration-300 text-stone-900 dark:text-stone-100`;
-        button.addEventListener('click', () => this.applySyntax('both'));  // Default to 'both', can change in child
+        button.addEventListener('click', () => this.applySyntax());  // Default to 'both', can change in child
         return button;
-    }
-
-    // Toggle markdown syntax at the current cursor position
-    applySyntax(position = 'both') {
-        const textarea = this.editor.usertextarea;
-        const { selectionStart, selectionEnd } = textarea;
-        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
-
-        const syntaxLength = this.syntax.length;
-
-        // Check which type of syntax to apply based on the position
-        let newText = '';
-        if(position === 'start'){
-            if (selectedText.startsWith(this.syntax)) {
-                // If text is already wrapped with the markdown syntax, remove it
-                const unformattedText = selectedText.slice(syntaxLength);
-                this.editor.insertText(unformattedText);
-            }else{
-                newText = `${this.syntax} ${selectedText || this.defaultText}`;
-                // Insert the new formatted text
-                this.editor.insertText(newText);
-            }
-        } else if (position === 'end') {
-            if (selectedText.startsWith(this.syntax)) {
-                // If text is already wrapped with the markdown syntax, remove it
-                const unformattedText = selectedText.slice(syntaxLength);
-                this.editor.insertText(unformattedText);
-            }else{
-                newText = `${selectedText || this.defaultText}${this.syntax}`;
-                // Insert the new formatted text
-                this.editor.insertText(newText);
-            }
-        } else {
-            if (selectedText.startsWith(this.syntax) && selectedText.endsWith(this.syntax)) {
-                // If text is already wrapped with the markdown syntax, remove it
-                const unformattedText = selectedText.slice(syntaxLength, -syntaxLength);
-                this.editor.insertText(unformattedText);
-            }else{
-                newText = `${this.syntax}${selectedText || this.defaultText}${this.syntax}`;
-                // Insert the new formatted text
-                this.editor.insertText(newText);
-            }
-        }
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/BlockQuoteTool.js
+++ b/src/plugins/markdown/Toolbar/tools/BlockQuoteTool.js
@@ -3,14 +3,28 @@ import MakeTool from '../MakeTool.js';
 class BlockQuoteTool extends MakeTool {
     constructor(editor) {
         // Call the parent constructor with the markdown syntax for italic (*)
-        super(editor, '>', 'Blockquote');
+        super(editor, 'Blockquote');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M4.58341 17.3211C3.55316 16.2274 3 15 3 13.0103C3 9.51086 5.45651 6.37366 9.03059 4.82318L9.92328 6.20079C6.58804 8.00539 5.93618 10.346 5.67564 11.822C6.21263 11.5443 6.91558 11.4466 7.60471 11.5105C9.40908 11.6778 10.8312 13.159 10.8312 15C10.8312 16.933 9.26416 18.5 7.33116 18.5C6.2581 18.5 5.23196 18.0095 4.58341 17.3211ZM14.5834 17.3211C13.5532 16.2274 13 15 13 13.0103C13 9.51086 15.4565 6.37366 19.0306 4.82318L19.9233 6.20079C16.588 8.00539 15.9362 10.346 15.6756 11.822C16.2126 11.5443 16.9156 11.4466 17.6047 11.5105C19.4091 11.6778 20.8312 13.159 20.8312 15C20.8312 16.933 19.2642 18.5 17.3312 18.5C16.2581 18.5 15.232 18.0095 14.5834 17.3211Z"></path></svg>
         `);
     }
 
     applySyntax() {
-        super.applySyntax('start');  // Only apply syntax at the start
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '>';
+        let newText = '';
+        if (selectedText.startsWith(syntax)) {
+            // Remove the blockquote syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length);
+        } else {
+            // Apply blockquote syntax
+            newText = `${syntax}${selectedText || 'Blockquote text'}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/BoldTool.js
+++ b/src/plugins/markdown/Toolbar/tools/BoldTool.js
@@ -2,11 +2,31 @@ import MakeTool from '../MakeTool.js';
 
 class BoldTool extends MakeTool {
     constructor(editor) {
-        // Call the parent constructor with the markdown syntax for bold (**)
-        super(editor, '**', 'Bold');
+        super(editor, 'Bold');
         this.button = this.createButton(`
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M8 11H12.5C13.8807 11 15 9.88071 15 8.5C15 7.11929 13.8807 6 12.5 6H8V11ZM18 15.5C18 17.9853 15.9853 20 13.5 20H6V4H12.5C14.9853 4 17 6.01472 17 8.5C17 9.70431 16.5269 10.7981 15.7564 11.6058C17.0979 12.3847 18 13.837 18 15.5ZM8 13V18H13.5C14.8807 18 16 16.8807 16 15.5C16 14.1193 14.8807 13 13.5 13H8Z"></path></svg>
-        `);
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                <path d="M8 11H12.5C13.8807 11 15 9.88071 15 8.5C15 7.11929 13.8807 6 12.5 6H8V11ZM18 15.5C18 17.9853 15.9853 20 13.5 20H6V4H12.5C14.9853 4 17 6.01472 17 8.5C17 9.70431 16.5269 10.7981 15.7564 11.6058C17.0979 12.3847 18 13.837 18 15.5ZM8 13V18H13.5C14.8807 18 16 16.8807 16 15.5C16 14.1193 14.8807 13 13.5 13H8Z"></path>
+            </svg>    
+        `)
+    }
+
+    // Apply bold syntax (**bold**)
+    applySyntax() {
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '**';
+        let newText = '';
+        if (selectedText.startsWith(syntax) && selectedText.endsWith(syntax)) {
+            // Remove the bold syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length, -syntax.length);
+        } else {
+            // Apply bold syntax
+            newText = `${syntax}${selectedText || 'Bold text'}${syntax}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/CheckListTool.js
+++ b/src/plugins/markdown/Toolbar/tools/CheckListTool.js
@@ -2,15 +2,28 @@ import MakeTool from '../MakeTool.js';
 
 class CheckListTool extends MakeTool {
     constructor(editor) {
-        super(editor, '- [x]', 'Check list');
+        super(editor, 'Check list');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M8.00008 6V9H5.00008V6H8.00008ZM3.00008 4V11H10.0001V4H3.00008ZM13.0001 4H21.0001V6H13.0001V4ZM13.0001 11H21.0001V13H13.0001V11ZM13.0001 18H21.0001V20H13.0001V18ZM10.7072 16.2071L9.29297 14.7929L6.00008 18.0858L4.20718 16.2929L2.79297 17.7071L6.00008 20.9142L10.7072 16.2071Z"></path></svg>
         `);
     }
     
-    // You can change how the syntax is applied for this specific tool:
     applySyntax() {
-        super.applySyntax('start');  // Only apply strikethrough at the start
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '- [x]';
+        let newText = '';
+        if (selectedText.startsWith(syntax)) {
+            // Remove the checklist syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length);
+        } else {
+            // Apply check list syntax
+            newText = `${syntax} ${selectedText || 'Check list text'}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/ItalicTool.js
+++ b/src/plugins/markdown/Toolbar/tools/ItalicTool.js
@@ -3,10 +3,28 @@ import MakeTool from '../MakeTool.js';
 class ItalicTool extends MakeTool {
     constructor(editor) {
         // Call the parent constructor with the markdown syntax for italic (*)
-        super(editor, '*', 'Italic');
+        super(editor, 'Italic');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M15 20H7V18H9.92661L12.0425 6H9V4H17V6H14.0734L11.9575 18H15V20Z"></path></svg>
         `);
+    }
+
+    applySyntax() {
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '*';
+        let newText = '';
+        if (selectedText.startsWith(syntax) && selectedText.endsWith(syntax)) {
+            // Remove the italic syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length, -syntax.length);
+        } else {
+            // Apply italic syntax
+            newText = `${syntax}${selectedText || 'Italic text'}${syntax}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/OLTool.js
+++ b/src/plugins/markdown/Toolbar/tools/OLTool.js
@@ -2,15 +2,28 @@ import MakeTool from '../MakeTool.js';
 
 class OLTool extends MakeTool {
     constructor(editor) {
-        super(editor, '1.', 'Ordered list');
+        super(editor, 'Ordered list');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M8 4H21V6H8V4ZM5 3V6H6V7H3V6H4V4H3V3H5ZM3 14V11.5H5V11H3V10H6V12.5H4V13H6V14H3ZM5 19.5H3V18.5H5V18H3V17H6V21H3V20H5V19.5ZM8 11H21V13H8V11ZM8 18H21V20H8V18Z"></path></svg>
         `);
     }
     
-    // You can change how the syntax is applied for this specific tool:
     applySyntax() {
-        super.applySyntax('start');  // Only apply strikethrough at the start
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '1. ';
+        let newText = '';
+        if (selectedText.startsWith(syntax)) {
+            // Remove the ordered syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length);
+        } else {
+            // Apply ordered list syntax
+            newText = `${syntax} ${selectedText || 'Ordered list text'}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/StrikethroughTool.js
+++ b/src/plugins/markdown/Toolbar/tools/StrikethroughTool.js
@@ -3,10 +3,28 @@ import MakeTool from '../MakeTool.js';
 class StrikethroughTool extends MakeTool {
     constructor(editor) {
         // Call the parent constructor with the markdown syntax for strikethrough (~~)
-        super(editor, '~~', 'Strikethrough');
+        super(editor, 'Strikethrough');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M17.1538 14C17.3846 14.5161 17.5 15.0893 17.5 15.7196C17.5 17.0625 16.9762 18.1116 15.9286 18.867C14.8809 19.6223 13.4335 20 11.5862 20C9.94674 20 8.32335 19.6185 6.71592 18.8555V16.6009C8.23538 17.4783 9.7908 17.917 11.3822 17.917C13.9333 17.917 15.2128 17.1846 15.2208 15.7196C15.2208 15.0939 15.0049 14.5598 14.5731 14.1173C14.5339 14.0772 14.4939 14.0381 14.4531 14H3V12H21V14H17.1538ZM13.076 11H7.62908C7.4566 10.8433 7.29616 10.6692 7.14776 10.4778C6.71592 9.92084 6.5 9.24559 6.5 8.45207C6.5 7.21602 6.96583 6.165 7.89749 5.299C8.82916 4.43299 10.2706 4 12.2219 4C13.6934 4 15.1009 4.32808 16.4444 4.98426V7.13591C15.2448 6.44921 13.9293 6.10587 12.4978 6.10587C10.0187 6.10587 8.77917 6.88793 8.77917 8.45207C8.77917 8.87172 8.99709 9.23796 9.43293 9.55079C9.86878 9.86362 10.4066 10.1135 11.0463 10.3004C11.6665 10.4816 12.3431 10.7148 13.076 11H13.076Z"></path></svg>
         `);
+    }
+
+    applySyntax() {
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '~';
+        let newText = '';
+        if (selectedText.startsWith(syntax) && selectedText.endsWith(syntax)) {
+            // Remove the strikethrough syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length, -syntax.length);
+        } else {
+            // Apply strikethrough syntax
+            newText = `${syntax}${selectedText || 'Strikethrough text'}${syntax}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 

--- a/src/plugins/markdown/Toolbar/tools/ULTool.js
+++ b/src/plugins/markdown/Toolbar/tools/ULTool.js
@@ -2,15 +2,28 @@ import MakeTool from '../MakeTool.js';
 
 class ULTool extends MakeTool {
     constructor(editor) {
-        super(editor, '-', 'Unordered list');
+        super(editor, 'Unordered list');
         this.button = this.createButton(`
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M8 4H21V6H8V4ZM4.5 6.5C3.67157 6.5 3 5.82843 3 5C3 4.17157 3.67157 3.5 4.5 3.5C5.32843 3.5 6 4.17157 6 5C6 5.82843 5.32843 6.5 4.5 6.5ZM4.5 13.5C3.67157 13.5 3 12.8284 3 12C3 11.1716 3.67157 10.5 4.5 10.5C5.32843 10.5 6 11.1716 6 12C6 12.8284 5.32843 13.5 4.5 13.5ZM4.5 20.4C3.67157 20.4 3 19.7284 3 18.9C3 18.0716 3.67157 17.4 4.5 17.4C5.32843 17.4 6 18.0716 6 18.9C6 19.7284 5.32843 20.4 4.5 20.4ZM8 11H21V13H8V11ZM8 18H21V20H8V18Z"></path></svg>
         `);
     }
     
-    // You can change how the syntax is applied for this specific tool:
     applySyntax() {
-        super.applySyntax('start');  // Only apply strikethrough at the start
+        const textarea = this.editor.usertextarea;
+        const { selectionStart, selectionEnd } = textarea;
+        const selectedText = textarea.value.substring(selectionStart, selectionEnd);
+
+        const syntax = '- ';
+        let newText = '';
+        if (selectedText.startsWith(syntax)) {
+            // Remove the Unordered syntax if it's already wrapped
+            newText = selectedText.slice(syntax.length);
+        } else {
+            // Apply Unordered list syntax
+            newText = `${syntax} ${selectedText || 'Unordered list text'}`;
+        }
+
+        this.editor.insertText(newText);
     }
 }
 


### PR DESCRIPTION
Move syntax toggling logic to individual tool classes for better modularity and maintainability