### PR TITLE
Support custom Markdown renderer and HTML sanitizer

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -20,6 +20,7 @@ class MarkdownEditor {
 
         // A marked instance with custom options and plugins
         this.mdRender = options.renderer || marked;
+        this.sanitizeHTML = options.sanitizer || function(html) { return html};
         this.init();
         this.undoRedoManager = new UndoRedoManager(this);
         this.listManager = new ListManager(this);
@@ -308,7 +309,7 @@ class MarkdownEditor {
     }
 
     renderPreview() {
-        if (this.preview) this.previewContent.innerHTML = this.mdRender(this.usertextarea.value);
+        if (this.preview) this.previewContent.innerHTML = this.sanitizeHTML(this.mdRender(this.usertextarea.value));
     }
 }
 

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -17,6 +17,9 @@ class MarkdownEditor {
         this.mode = options.mode || 'plain';
         this.preview = (this.options.toolbar) ? this.options.toolbar.includes('preview') : true;
         this.previewTimer = null;
+
+        // A marked instance with custom options and plugins
+        this.mdRender = options.renderer || marked;
         this.init();
         this.undoRedoManager = new UndoRedoManager(this);
         this.listManager = new ListManager(this);
@@ -305,7 +308,7 @@ class MarkdownEditor {
     }
 
     renderPreview() {
-        if (this.preview) this.previewContent.innerHTML = marked(this.usertextarea.value);
+        if (this.preview) this.previewContent.innerHTML = this.mdRender(this.usertextarea.value);
     }
 }
 

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -34,7 +34,8 @@ class MarkdownEditor {
         this.applyDefaultAttributes();
         this.buildEditorLayout();
         this.addInputListener();
-        this.render();
+        this.renderHybrid();
+        this.renderPreview();
     }
 
     isTextareaValid() {
@@ -167,7 +168,7 @@ class MarkdownEditor {
         if (!this.preview) return;
         clearTimeout(this.previewTimer);
         this.previewTimer = setTimeout(() => {
-            this.previewContent.innerHTML = marked(this.usertextarea.value);
+            this.renderPreview(this.usertextarea.value);
         }, 150); // 150ms delay feels instant but saves CPU
     }
 
@@ -216,7 +217,8 @@ class MarkdownEditor {
         // Scroll the textarea to the inserted text
         this.scrollToView();
 
-        this.render();
+        this.renderHybrid();
+        this.renderPreview();
     }
 
     scrollToView() {
@@ -302,9 +304,7 @@ class MarkdownEditor {
         this.displayLayer.innerHTML = highlighted;
     }
 
-    render() {
-        // Initial render or manual trigger
-        this.renderHybrid();
+    renderPreview() {
         if (this.preview) this.previewContent.innerHTML = marked(this.usertextarea.value);
     }
 }


### PR DESCRIPTION
Allow for custom options in Marked and an HTML santizer. 

Sample usage:

```javascript
function mkRender() {
    const mdRender = new Marked()

    mdRender.setOptions({
      async: false,
      gfm: true,
      pedantic: false,
      breaks: false,
    })
    mdRender.use(
        markedHighlight({
          langPrefix: "hljs language-",
          highlight(code, lang) {
            const lowerLang = lang.toLowerCase()
            const language = hljs.getLanguage(lowerLang) ? lowerLang : "plaintext"
            return hljs.highlight(code, { language }).value
          },
        }),
    )

    return mdRender.parse
}

const editor = new MarkdownEditor('#markdown-editor', {
  placeholder: 'Write your markdown...',
  mode: "hybrid",
  toolbar: ['heading', 'bold', 'italic', 'strikethrough', 'ul', 'ol', 'checklist', 'blockquote', 'link', 'image', 'preview'],
  renderer: mkRender(),
  sanitizer: DOMPurify.sanitize,
});
```